### PR TITLE
new reader for llm that manages context + added function to conclude …

### DIFF
--- a/src/components/dialog_component/cpp_dialog_component/CMakeLists.txt
+++ b/src/components/dialog_component/cpp_dialog_component/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(text_to_speech_interfaces REQUIRED)
 find_package(scheduler_interfaces REQUIRED)
 find_package(execute_dance_interfaces REQUIRED)
 find_package(cartesian_pointing_interfaces REQUIRED)
+find_package(blackboard_interfaces REQUIRED)
 #find_package(YCM REQUIRED)
 find_package(YARP REQUIRED COMPONENTS dev os sig REQUIRED)
 
@@ -72,6 +73,7 @@ ament_target_dependencies(${PROJECT_NAME}
 "scheduler_interfaces"
 "execute_dance_interfaces"
 "cartesian_pointing_interfaces"
+"blackboard_interfaces"
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/components/dialog_component/cpp_dialog_component/include/DialogComponent.hpp
+++ b/src/components/dialog_component/cpp_dialog_component/include/DialogComponent.hpp
@@ -51,6 +51,7 @@
 #include <scheduler_interfaces/srv/end_tour.hpp>
 #include <scheduler_interfaces/srv/update_poi.hpp>
 #include <scheduler_interfaces/srv/set_language.hpp>
+#include <scheduler_interfaces/srv/end_tour.hpp>
 
 // ExecuteDance Interfaces
 #include <execute_dance_interfaces/srv/execute_dance.hpp>
@@ -59,6 +60,9 @@
 // CartesianPointing Interfaces
 #include <cartesian_pointing_interfaces/srv/point_at.hpp>
 #include <cartesian_pointing_interfaces/srv/is_motion_done.hpp>
+
+// BlackBoard Interfaces
+#include <blackboard_interfaces/srv/set_all_ints_with_prefix_blackboard.hpp>
 
 #include "nlohmann/json.hpp"
 #include <random>
@@ -120,6 +124,7 @@ protected:
     void ResetDance(); // ROS2 service client to ResetDanceComponent to reset the dance with the given name
     void ExecutePointing(std::string pointingTarget); // ROS2 service client to CartesianPointingComponent to point at the given target
     void SetFaceExpression(std::string expressionName); // ROS2 service client to FaceExpressionComponent to set the face expression with the given name
+    void ResetTourAndFlags(); // Resets the tour in the SchedulerComponent and in the BlackBoardComponent
 
 private:
     // ChatGPT
@@ -251,6 +256,12 @@ private:
 
     std::shared_ptr<rclcpp::Node> isMotionDoneClientNode;
     std::shared_ptr<rclcpp::Client<cartesian_pointing_interfaces::srv::IsMotionDone>> isMotionDoneClient;
+
+    std::shared_ptr<rclcpp::Node> schedulerEndTourClientNode;
+    std::shared_ptr<rclcpp::Client<scheduler_interfaces::srv::EndTour>> schedulerEndTourClient;
+
+    std::shared_ptr<rclcpp::Node> blackBoardResetClientNode;
+    std::shared_ptr<rclcpp::Client<blackboard_interfaces::srv::SetAllIntsWithPrefixBlackboard>> blackBoardResetClient;
 
 };
 


### PR DESCRIPTION
This branch includes the following changes:
- The dialog component is updated to read the new output of the LLM that manages the context, edited in this [new branch of tour-guide-robot](https://github.com/hsp-iit/tour-guide-robot/tree/feat/convince_llm1_prompt), for which there's a dedicated PR.
- The dialog component now also has a new function that resets the scheduler component and the blackboard in case the user asks to terminate the tour at any POI.

NOTE: This changes the way the dialog component extracts information from the user's interaction, and necessitates that any tour-guide-robot involved (the one in the container r1_talk and the one containing UC3) has the updates made in the branch linked above.

These changes have been tested in simulation. I have started the tour, reached POI1, and then asked to conclude the tour, the robot has reached POI0. In the same session, I asked to restart the tour, and the robot reached POI1 and then POI2 (after asking to continue again). At POI2, I asked again to conclude the tour. The robot has reached POI0 again.